### PR TITLE
Remove Google Analytics scripts from blog pages

### DIFF
--- a/blog/serverless-ci-cd.html
+++ b/blog/serverless-ci-cd.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CRCPGWMDK7"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-CRCPGWMDK7');
-    </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="Description" content="Serverless CI/CD: Automating AWS Lambda releases using Step Functions for end-to-end automation and reliability.">

--- a/blog/spark-etl-pipelines.html
+++ b/blog/spark-etl-pipelines.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CRCPGWMDK7"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-CRCPGWMDK7');
-    </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="Description" content="Learn how to fine-tune your Spark ETL pipelines for maximum efficiency with real-time data processing - Blog by Bharath Bhaskar, software engineer and tennis enthusiast.">


### PR DESCRIPTION
## Summary
- remove Google Analytics tracking from `serverless-ci-cd.html`
- remove Google Analytics tracking from `spark-etl-pipelines.html`

## Testing
- `npm test` *(fails: Could not read package.json)
